### PR TITLE
Postmessage bridge

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
+++ b/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
@@ -28,12 +28,19 @@ public class BrowserClient extends WebViewClient {
     }
 
     @Override
+    @TargetApi(Build.VERSION_CODES.KITKAT)
     public void onPageFinished(WebView view, String url) {
         super.onPageFinished(view, url);
         Map<String, Object> data = new HashMap<>();
         data.put("url", url);
 
         FlutterWebviewPlugin.channel.invokeMethod("onUrlChanged", data);
+        String script = "if (!window.breezReceiveMessage) {" +
+                    "window.breezReceiveMessage = function(event) {Android.getPostMessage(event.data);};" +
+                    "window.addEventListener('message', window.breezReceiveMessage, false);" +
+                "}";
+        view.evaluateJavascript(script, null);
+
 
         data.put("type", "finishLoad");
         FlutterWebviewPlugin.channel.invokeMethod("onState", data);

--- a/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
+++ b/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
@@ -6,6 +6,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.annotation.TargetApi;
+import android.os.Build;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
+++ b/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
@@ -5,6 +5,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.annotation.TargetApi;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
This PR implement a way for dual communication between the native code and the webview.
The code now listens for postMessage on both browsers and emit a stream event up to the dart code.
So  the following use cases can be implemented:

Calling a function in dart from webview:
Just emit postMessage and the event will be received in the plugin postMessage stream.

Calling a function in webview from dart:
use evalJavascript to run a code on the webview. (was already implemented).
